### PR TITLE
Wip transfer

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,0 +1,5 @@
+version: 1.2
+workflows:
+ - name: TheiaCov_mpox_transfer
+   subclass: WDL
+   primaryDescriptorPath: /workflows/TheiaCov_mpox_transfer.wdl

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains all our mpox related workflows. 
 
-Currently we use the XGen tiled amplicon primer scheme for WGS. We then perform genome assemlby using [Theiagen Genomic's PHB wf_theiacov_illumina_pe.wdl](https://github.com/theiagen/public_health_bioinformatics/tree/main/workflows/theiacov) on the Terra platform. Following assembly we transfer the resutls and intermediate files to our gcp buckets using the TheaiCov_mpox_transfer.wdl.
+Currently we use the XGen tiled amplicon primer scheme for WGS. We then perform genome assembly using [Theiagen Genomic's PHB wf_theiacov_illumina_pe.wdl](https://github.com/theiagen/public_health_bioinformatics/tree/main/workflows/theiacov) on the Terra platform. Following assembly we transfer the resutls and intermediate files to our GCP buckets using the TheaiCov_mpox_transfer.wdl.
 
 ## transfer TheiaCov_mpox_transfer.wdl
 This wdl workflow transfers the result files and intermediate files from the wf_theiacov_illumina_pe.wdl workflow to our bucket.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # CDPHE-mpox
+
+This repo contains all our mpox related workflows. 
+
+Currently we use the XGen tiled amplicon primer scheme for WGS. We then perform genome assemlby using Theiagen Genomic's PHB wf_theiacov_illumina_pe.wdl (https://github.com/theiagen/public_health_bioinformatics/tree/main/workflows/theiacov) on the Terra platform. Following assembly we transfer the resutls and intermediate files to our gcp buckets using the TheaiCov_mpox_transfer.wdl.
+
+## transfer TheiaCov_mpox_transfer.wdl
+This wdl workflow transfers the result files and intermediate files from the wf_theiacov_illumina_pe.wdl workflow to our bucket.
+
+### inputs
+
+|Input Variable| description |
+|:-------------:|:------------:|
+| sample_name| column with the list of sample names (e.g. the entity:data_name_id)|
+|transfer_bucket_path| user defined google bucket for where the files will be transferred to, string|
+|aligned_bam| bam files |
+|assembly_fasta| consensus fasteas|
+|consesnus_stats||
+|ivar_tsv| vcf file output from ivar|
+|ivar_vcf| vcf file ouptut from ivar|
+|kraken_report| kraken report output from kraken|
+| kraken_report_dehosted|kraken report output from kraken|
+|nextclade_json| nextclade json file output from nextclade|
+|nextclade_tsv| nextclade file output from nextclade|
+|read1_dehosted| scrubbed fastq file of human read data|
+|read2_dehosted| scrubbed fastq file of human read data|

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains all our mpox related workflows. 
 
-Currently we use the XGen tiled amplicon primer scheme for WGS. We then perform genome assemlby using Theiagen Genomic's PHB wf_theiacov_illumina_pe.wdl (https://github.com/theiagen/public_health_bioinformatics/tree/main/workflows/theiacov) on the Terra platform. Following assembly we transfer the resutls and intermediate files to our gcp buckets using the TheaiCov_mpox_transfer.wdl.
+Currently we use the XGen tiled amplicon primer scheme for WGS. We then perform genome assemlby using [Theiagen Genomic's PHB wf_theiacov_illumina_pe.wdl](https://github.com/theiagen/public_health_bioinformatics/tree/main/workflows/theiacov) on the Terra platform. Following assembly we transfer the resutls and intermediate files to our gcp buckets using the TheaiCov_mpox_transfer.wdl.
 
 ## transfer TheiaCov_mpox_transfer.wdl
 This wdl workflow transfers the result files and intermediate files from the wf_theiacov_illumina_pe.wdl workflow to our bucket.

--- a/workflows/TheiaCov_mpox_transfer.wdl
+++ b/workflows/TheiaCov_mpox_transfer.wdl
@@ -19,6 +19,8 @@ workflow theiacov_mpox_transfer {
         File kraken_report_dehosted
         File nextclade_json
         File nextclade_tsv
+        File read1_dehosted
+        File read2_dehosted
 
     }
 
@@ -38,7 +40,9 @@ workflow theiacov_mpox_transfer {
             kraken_report = kraken_report,
             kraken_report_dehosted = kraken_report_dehosted,
             nextclade_json = nextclade_json,
-            nextclade_tsv = nextclade_tsv
+            nextclade_tsv = nextclade_tsv,
+            read1_dehosted = read1_dehosted,
+            read2_dehosted = read2_dehosted
 
     }
 
@@ -70,6 +74,8 @@ task transfer{
         File kraken_report_dehosted
         File nextclade_json
         File nextclade_tsv
+        File read1_dehosted
+        File read2_dehosted
 
     }
     
@@ -84,6 +90,8 @@ task transfer{
         gsutil -m cp ~{kraken_report_dehosted} ~{transfer_bucket}/kraken/
         gsutil -m cp ~{nextclade_json} ~{transfer_bucket}/nextclade/
         gsutil -m cp ~{nextclade_tsv} ~{transfer_bucket}/nextclade/
+        gsutil -m cp ~{read1_dehosted} ~{transfer_bucket}/fastq_scrubbed/
+        gsutil -m cp ~{read2_dehosted} ~{transfer_bucket}/fastq_scrubbed/
 
         # transfer date
         transferdate=`date`

--- a/workflows/TheiaCov_mpox_transfer.wdl
+++ b/workflows/TheiaCov_mpox_transfer.wdl
@@ -1,0 +1,105 @@
+version 1.0
+
+# compatible with thieaCov_PE_assembly PHB v2.3.0
+
+# begin workflow
+workflow theiacov_mpox_transfer {
+
+    input {
+        String sample_name
+        String transfer_bucket_path
+        
+        # outputs from theiacov
+        File aligned_bam
+        File assembly_fasta
+        File consensus_stats
+        File ivar_tsv
+        File ivar_vcf
+        File kraken_report
+        File kraken_report_dehosted
+        File nextclade_json
+        File nextclade_tsv
+
+    }
+
+    # secret variables
+    String transfer_bucket = sub(transfer_bucket_path, "/$", "")
+
+    call transfer{
+        input:
+            sample_name = sample_name, 
+            transfer_bucket = transfer_bucket,
+
+            aligned_bam = aligned_bam,
+            assembly_fasta = assembly_fasta,
+            consensus_stats = consensus_stats,
+            ivar_tsv = ivar_tsv,
+            ivar_vcf = ivar_vcf,
+            kraken_report = kraken_report,
+            kraken_report_dehosted = kraken_report_dehosted,
+            nextclade_json = nextclade_json,
+            nextclade_tsv = nextclade_tsv
+
+    }
+
+
+    output {
+        
+        String transfer_date=transfer.transfer_date
+    }
+}
+
+task transfer{
+
+    meta{
+        description: "transfer output files from TheiaCov mpox module"
+    }
+
+    input{
+        
+        String sample_name
+        String transfer_bucket
+        
+        # outputs from theiacov
+        File aligned_bam
+        File assembly_fasta
+        File consensus_stats
+        File ivar_tsv
+        File ivar_vcf
+        File kraken_report
+        File kraken_report_dehosted
+        File nextclade_json
+        File nextclade_tsv
+
+    }
+    
+
+    command <<<
+        gsutil -m cp ~{aligned_bam} ~{transfer_bucket}/alignments/
+        gsutil -m cp ~{assembly_fasta} ~{transfer_bucket}/assemblies/
+        gsutil -m cp ~{consensus_stats} ~{transfer_bucket}/bam_stats/
+        gsutil -m cp ~{ivar_tsv} ~{transfer_bucket}/ivar/
+        gsutil -m cp ~{ivar_vcf} ~{transfer_bucket}/ivar/
+        gsutil -m cp ~{kraken_report} ~{transfer_bucket}/kraken/
+        gsutil -m cp ~{kraken_report_dehosted} ~{transfer_bucket}/kraken/
+        gsutil -m cp ~{nextclade_json} ~{transfer_bucket}/nextclade/
+        gsutil -m cp ~{nextclade_tsv} ~{transfer_bucket}/nextclade/
+
+        # transfer date
+        transferdate=`date`
+        echo $transferdate | tee TRANSFERDATE
+
+    >>>
+    output {
+        String transfer_date = read_string("TRANSFERDATE")
+    }
+
+    runtime {
+        docker: "theiagen/utility:1.0"
+        memory: "16 GiB"
+        cpu: 4
+        disks: "local-disk 50 SSD"
+        preemptible: 0
+    }
+
+}


### PR DESCRIPTION
This PR closes #1 

##  Aim, context, and functionality 🎯
This PR addresses the need for a transfer workflow to transfer the results of wf_theiacov_illumina_pe.wdl for mpox. The results it transfers are bam files, consensus sequence fasta files, ivar output files, kraken reports files, nextclade output files, and scrubbed fastq files. 

## Workflow Changes ✅
#### Upstream effects 
(e.g. preprocessing of data)
None

#### Input changes 
(e.g. file changes, names of data fields, etc.)
The transfer wdl requires "transfer_bucket_path" - this can be written as a string or this can be included in the original terra data table and added as "this.datatables.transfer_bucket_path"

#### Output changes 
(e.g. file changes, names of data fields, etc.)
None

#### Downstream effects 
(e.g. BigQuery organization, file structure organization, file content organization)
Resutls are transfered the mpox project bucket. 

##  Testing 🛠️
**Test dataset(s):**
test_mpox_primers_0001_miseq (XGen samples only)

**Test(s) performed:**
ran the transfer wdl on terra.

**Results (including if the results matched the expected results):**
All expected files were transferred successful to our buckets. 

## Developer Checklist 👷‍♀️ 
- [x] Prior to development, issues were discussed with the bioinformatics team members and approved
- [x] Code has been refactored to sufficiently address the issues this pull request closes
- [x] Testing was performed and the results from testing match the expected results
- [x] All code changes match our style guide
- [x] README has been updated to reflect changes
- [ ] Workflow diagrams in READMEs have been updated to reflect changes

## Reviewer Checklist 🔍
- [ ] Met with developer to review all changes and testing performed
- [ ] Code refactoring sufficiently address the issue(s) that this pull request closes
- [ ] All code meets style guide critera
- [ ] Confirm testing was sufficient (e.g. correct dataset was used for testing, results match the expected results). If not, the developer will perform additional testing which should be documented in the testing section above.
- [ ] New version release number has been decided upon (if applicable)
